### PR TITLE
PDX-355: Use relative path in ProvarDX properties JSON

### DIFF
--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -50,7 +50,7 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
           testCasePath.replace(/^\/tests\//, '/')
         );
       }
-      if (propertiesInstance.testPlan) {
+      if (propertiesInstance?.testPlan) {
         propertiesInstance.testPlan = propertiesInstance.testPlan.map((testCaseInstancePath: string) =>
           testCaseInstancePath.replace(/^\/plans\//, '/')
         );

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -45,6 +45,12 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
       /* eslint-disable */
       const propertiesData = fileSystem.readFileSync(propertiesFilePath, { encoding: 'utf8' });
       const propertiesInstance = JSON.parse(propertiesData);
+      propertiesInstance.testCase = propertiesInstance.testCase.map((testCasePath: string) =>
+        testCasePath.replace(/^\/tests\//, '/')
+      );
+      propertiesInstance.testPlan = propertiesInstance.testPlan.map((testCaseInstancePath: string) =>
+        testCaseInstancePath.replace(/^\/plans\//, '/')
+      );
       const rawProperties = JSON.stringify(propertiesInstance);
       const userSupport = new UserSupport();
       const updateProperties = userSupport.prepareRawProperties(rawProperties);

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -45,12 +45,16 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
       /* eslint-disable */
       const propertiesData = fileSystem.readFileSync(propertiesFilePath, { encoding: 'utf8' });
       const propertiesInstance = JSON.parse(propertiesData);
-      propertiesInstance.testCase = propertiesInstance.testCase.map((testCasePath: string) =>
-        testCasePath.replace(/^\/tests\//, '/')
-      );
-      propertiesInstance.testPlan = propertiesInstance.testPlan.map((testCaseInstancePath: string) =>
-        testCaseInstancePath.replace(/^\/plans\//, '/')
-      );
+      if (propertiesInstance?.testCase) {
+        propertiesInstance.testCase = propertiesInstance.testCase.map((testCasePath: string) =>
+          testCasePath.replace(/^\/tests\//, '/')
+        );
+      }
+      if (propertiesInstance.testPlan) {
+        propertiesInstance.testPlan = propertiesInstance.testPlan.map((testCaseInstancePath: string) =>
+          testCaseInstancePath.replace(/^\/plans\//, '/')
+        );
+      }
       const rawProperties = JSON.stringify(propertiesInstance);
       const userSupport = new UserSupport();
       const updateProperties = userSupport.prepareRawProperties(rawProperties);


### PR DESCRIPTION
ProvarDX properties JSON uses the path relative to the test project to process the file/folder paths included in the testCase and testPlan attributes.
ProvarDX would then support both:
"testPlan":[
    "/Time Tracking/Timesheets/Validate Timesheet Hours.testinstance",
    "/plans/Time Tracking/Timesheets/Validate Timesheet Hours.testinstance"
]


"testCase":[
    "/Time Tracking/Timesheets/Validate Timesheet Hours.testinstance",
    "/tests/Time Tracking/Timesheets/Validate Timesheet Hours.testinstance"
]

using regex to manipulate testCase and testPlan array Values for excluding tests/ or plans/