### PR TITLE
PDX-410: Show test run output on terminal by default

### DIFF
--- a/messages/provar.automation.test.run.md
+++ b/messages/provar.automation.test.run.md
@@ -17,3 +17,7 @@ Run the tests as specified in the loaded properties file.
 # success_message
 
 The tests were run successfully.
+
+# flags.output-file.summary
+
+Outputs the test run logs to a file.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@oclif/core": "^3.26.2",
     "@salesforce/core": "^7.2.0",
     "@salesforce/sf-plugins-core": "^9.0.1",
-    "@provartesting/provardx-plugins-utils": "1.1.0",
+    "@provartesting/provardx-plugins-utils": "1.2.0",
     "axios": "^1.6.7",
     "xml-js": "^1.6.11"
   },

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -169,7 +169,7 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
       errorObj.setMessage(`Error ${getStringAfterSubstring(logMessage, 'Error')}`);
       this.genericErrorHandler.addErrorsToList(errorObj);
     }
-    fileSystem.appendFileSync(logFilePath, logMessage, { encoding: 'utf-8' });
+    fileSystem.writeFileSync(logFilePath, logMessage, { encoding: 'utf-8' });
   }
 
   private getFailureMessagesFromXML(filePath: string): void {

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -104,12 +104,7 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
         userInfoString +
         ' Runtests';
 
-      // if (flags['output-file']) {
-      // const logFilePath = path.resolve(flags['output-file'] ?? '');
       await this.runJavaCommand(testRunCommand, flags['output-file'] ?? '');
-      // } else {
-      //   execSync(testRunCommand, { stdio: 'inherit' });
-      // }
     } catch (error: any) {
       if (error.name === 'SyntaxError') {
         const errorObj: GenericError = new GenericError();

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -137,24 +137,28 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
       resolvers.done = resolve;
       resolvers.error = error;
     });
-    const javaProcessOutput = spawn(command, { shell: true, stdio: ['pipe', 'pipe', 'pipe'] });
+    try {
+      const javaProcessOutput = spawn(command, { shell: true, stdio: ['pipe', 'pipe', 'pipe'] });
 
-    javaProcessOutput.stdout.on('data', (data: { toString: () => string }) => {
-      const logMessage = data.toString().trim();
-      this.extractReportAndAddFailuresToErrorHandler(logMessage, logFilePath);
-    });
-    javaProcessOutput.stderr.on('error', (error: { toString: () => string }) => {
-      const logError = error.toString().trim();
-      this.extractReportAndAddFailuresToErrorHandler(logError, logFilePath);
-    });
-    javaProcessOutput.stderr.on('data', (error: { toString: () => string }) => {
-      const logError = error.toString().trim();
-      this.extractReportAndAddFailuresToErrorHandler(logError, logFilePath);
-    });
+      javaProcessOutput.stdout.on('data', (data: { toString: () => string }) => {
+        const logMessage = data.toString().trim();
+        this.extractReportAndAddFailuresToErrorHandler(logMessage, logFilePath);
+      });
+      javaProcessOutput.stderr.on('error', (error: { toString: () => string }) => {
+        const logError = error.toString().trim();
+        this.extractReportAndAddFailuresToErrorHandler(logError, logFilePath);
+      });
+      javaProcessOutput.stderr.on('data', (error: { toString: () => string }) => {
+        const logError = error.toString().trim();
+        this.extractReportAndAddFailuresToErrorHandler(logError, logFilePath);
+      });
 
-    javaProcessOutput.stderr.on('finish', (error: { toString: () => string }) => {
-      resolvers.done();
-    });
+      javaProcessOutput.stderr.on('finish', (error: { toString: () => string }) => {
+        resolvers.done();
+      });
+    } catch (error: any) {
+      return;
+    }
     return promise;
   }
 
@@ -183,6 +187,7 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
         error.setMessage('The user does not have permissions to create the output file.');
         this.genericErrorHandler.addErrorsToList(error);
       }
+      throw error;
     }
   }
 

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -1,5 +1,6 @@
 import * as fileSystem from 'node:fs';
 import { execSync, spawn } from 'node:child_process';
+import * as path from 'node:path';
 import { SfCommand, Flags } from '@salesforce/sf-plugins-core';
 import { xml2json } from 'xml-js';
 import {
@@ -91,7 +92,6 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
         this.genericErrorHandler.addErrorsToList(errorObj);
         return sfProvarAutomationTestRun.populateResult(flags, this.genericErrorHandler, messages, this.log.bind(this));
       }
-      const logFilePath = projectPath + '/log.txt';
 
       const provarDxJarPath = propertiesInstance.provarHome + '/provardx/provardx.jar';
       const testRunCommand =
@@ -105,6 +105,7 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
         ' Runtests';
 
       if (flags['output-file']) {
+        const logFilePath = path.resolve(flags['output-file']);
         await this.runJavaCommand(testRunCommand, logFilePath);
       } else {
         execSync(testRunCommand, { stdio: 'inherit' });

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -169,7 +169,21 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
       errorObj.setMessage(`Error ${getStringAfterSubstring(logMessage, 'Error')}`);
       this.genericErrorHandler.addErrorsToList(errorObj);
     }
-    fileSystem.writeFileSync(logFilePath, logMessage, { encoding: 'utf-8' });
+    try {
+      fileSystem.writeFileSync(logFilePath, logMessage, { encoding: 'utf-8' });
+    } catch (error: any) {
+      if (error.code === 'ENOENT') {
+        const error: GenericError = new GenericError();
+        error.setCode('INVALID_PATH');
+        error.setMessage(`The provided output file path does not exist or is invalid.`);
+        this.genericErrorHandler.addErrorsToList(error);
+      } else if (error.code === 'EPERM' || error.code === 'EACCES') {
+        const error: GenericError = new GenericError();
+        error.setCode('INSUFFICIENT_PERMISSIONS');
+        error.setMessage('The user does not have permissions to create the output file.');
+        this.genericErrorHandler.addErrorsToList(error);
+      }
+    }
   }
 
   private getFailureMessagesFromXML(filePath: string): void {

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -16,7 +16,7 @@ import {
   SfProvarCommandResult,
   Messages,
 } from '@provartesting/provardx-plugins-utils';
-import { SfProvarAutomationTestRun } from '../../../../result/sfProvarAutomationTestRunResult.js';
+import { SfProvarAutomationTestRunResult } from '../../../../result/sfProvarAutomationTestRunResult.js';
 
 Messages.importMessagesDirectoryFromMetaUrl(import.meta.url);
 const mdFile: string = 'provar.automation.test.run';
@@ -39,14 +39,19 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
     const { flags } = await this.parse(ProvarAutomationTestRun);
     const config: ProvarConfig = await ProvarConfig.loadConfig(this.genericErrorHandler);
     const propertiesFilePath = config.get('PROVARDX_PROPERTIES_FILE_PATH')?.toString();
-    const sfProvarAutomationTestRun = new SfProvarAutomationTestRun();
+    const sfProvarAutomationTestRunResult = new SfProvarAutomationTestRunResult();
 
     if (propertiesFilePath === undefined || !fileSystem.existsSync(propertiesFilePath)) {
       const errorObj: GenericError = new GenericError();
       errorObj.setCode('MISSING_FILE');
       errorObj.setMessage(errorMessages.MISSING_FILE_ERROR);
       this.genericErrorHandler.addErrorsToList(errorObj);
-      return sfProvarAutomationTestRun.populateResult(flags, this.genericErrorHandler, messages, this.log.bind(this));
+      return sfProvarAutomationTestRunResult.populateResult(
+        flags,
+        this.genericErrorHandler,
+        messages,
+        this.log.bind(this)
+      );
     }
 
     try {
@@ -81,7 +86,12 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
         this.genericErrorHandler
       );
       if (userInfo === null) {
-        return sfProvarAutomationTestRun.populateResult(flags, this.genericErrorHandler, messages, this.log.bind(this));
+        return sfProvarAutomationTestRunResult.populateResult(
+          flags,
+          this.genericErrorHandler,
+          messages,
+          this.log.bind(this)
+        );
       }
       const userInfoString = userSupport.prepareRawProperties(JSON.stringify({ dxUsers: userInfo }));
       const projectPath = propertiesInstance.projectPath;
@@ -90,7 +100,12 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
         errorObj.setCode('INVALID_PATH');
         errorObj.setMessage('projectPath does not exist');
         this.genericErrorHandler.addErrorsToList(errorObj);
-        return sfProvarAutomationTestRun.populateResult(flags, this.genericErrorHandler, messages, this.log.bind(this));
+        return sfProvarAutomationTestRunResult.populateResult(
+          flags,
+          this.genericErrorHandler,
+          messages,
+          this.log.bind(this)
+        );
       }
 
       const provarDxJarPath = propertiesInstance.provarHome + '/provardx/provardx.jar';
@@ -112,7 +127,12 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
         errorObj.setMessage(errorMessages.MALFORMED_FILE_ERROR);
         this.genericErrorHandler.addErrorsToList(errorObj);
       } else if (error.name === 'MultipleFailureError') {
-        return sfProvarAutomationTestRun.populateResult(flags, this.genericErrorHandler, messages, this.log.bind(this));
+        return sfProvarAutomationTestRunResult.populateResult(
+          flags,
+          this.genericErrorHandler,
+          messages,
+          this.log.bind(this)
+        );
       } else {
         const errorObj: GenericError = new GenericError();
         errorObj.setCode('GENERIC_ERROR');
@@ -120,7 +140,12 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
         this.genericErrorHandler.addErrorsToList(errorObj);
       }
     }
-    return sfProvarAutomationTestRun.populateResult(flags, this.genericErrorHandler, messages, this.log.bind(this));
+    return sfProvarAutomationTestRunResult.populateResult(
+      flags,
+      this.genericErrorHandler,
+      messages,
+      this.log.bind(this)
+    );
   }
 
   private async runJavaCommand(command: string, logFilePath: string): Promise<void> {
@@ -169,7 +194,7 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
       this.genericErrorHandler.addErrorsToList(errorObj);
     }
 
-    if (!logFilePath) {
+    if (logFilePath) {
       try {
         fileSystem.appendFileSync(path.resolve(logFilePath), logMessage, { encoding: 'utf-8' });
       } catch (error: any) {

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -174,7 +174,7 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
       this.genericErrorHandler.addErrorsToList(errorObj);
     }
     try {
-      fileSystem.writeFileSync(logFilePath, logMessage, { encoding: 'utf-8' });
+      fileSystem.appendFileSync(logFilePath, logMessage, { encoding: 'utf-8' });
     } catch (error: any) {
       if (error.code === 'ENOENT') {
         const error: GenericError = new GenericError();

--- a/src/commands/provar/automation/test/run.ts
+++ b/src/commands/provar/automation/test/run.ts
@@ -169,7 +169,7 @@ export default class ProvarAutomationTestRun extends SfCommand<SfProvarCommandRe
       this.genericErrorHandler.addErrorsToList(errorObj);
     }
 
-    if (logFilePath.length > 0) {
+    if (!logFilePath) {
       try {
         fileSystem.appendFileSync(path.resolve(logFilePath), logMessage, { encoding: 'utf-8' });
       } catch (error: any) {

--- a/src/result/sfProvarAutomationTestRunResult.ts
+++ b/src/result/sfProvarAutomationTestRunResult.ts
@@ -1,0 +1,40 @@
+import {
+  ErrorHandler,
+  GenericErrorHandler,
+  SfProvarCommandResult,
+  SFProvarResult,
+} from '@provartesting/provardx-plugins-utils';
+import { Messages } from '@salesforce/core';
+
+/* eslint-disable */
+export class SfProvarAutomationTestRun extends SFProvarResult {
+  /**
+   * Declaring return type and populating return object for async run method of the commands.
+   *
+   */
+
+  public populateResult(
+    flags: any,
+    errorHandler: ErrorHandler | GenericErrorHandler,
+    messages: Messages<string>,
+    log: Function
+  ): SfProvarCommandResult {
+    let result: SfProvarCommandResult = { success: true };
+
+    const errorObjects: Error[] | object[] = errorHandler.getErrors();
+    if (errorObjects.length > 0) {
+      if (!flags['json']) {
+        throw messages.createError('error.MultipleFailure', errorHandler.errorsToStringArray());
+      }
+      result = {
+        success: false,
+        errors: errorObjects,
+      };
+    } else {
+      if (flags['output-file']) {
+        log(`The test results are stored in ${flags['output-file']}`);
+      }
+    }
+    return result;
+  }
+}

--- a/src/result/sfProvarAutomationTestRunResult.ts
+++ b/src/result/sfProvarAutomationTestRunResult.ts
@@ -7,7 +7,7 @@ import {
 import { Messages } from '@salesforce/core';
 
 /* eslint-disable */
-export class SfProvarAutomationTestRun extends SFProvarResult {
+export class SfProvarAutomationTestRunResult extends SFProvarResult {
   /**
    * Declaring return type and populating return object for async run method of the commands.
    *

--- a/src/result/sfProvarAutomationTestRunResult.ts
+++ b/src/result/sfProvarAutomationTestRunResult.ts
@@ -22,6 +22,7 @@ export class SfProvarAutomationTestRun extends SFProvarResult {
     let result: SfProvarCommandResult = { success: true };
 
     const errorObjects: Error[] | object[] = errorHandler.getErrors();
+    log();
     if (errorObjects.length > 0) {
       if (!flags['json']) {
         throw messages.createError('error.MultipleFailure', errorHandler.errorsToStringArray());
@@ -31,7 +32,6 @@ export class SfProvarAutomationTestRun extends SFProvarResult {
         errors: errorObjects,
       };
     } else {
-      log();
       messages.messages.has('success_message') ? log(messages.getMessage('success_message')) : '';
     }
     return result;

--- a/src/result/sfProvarAutomationTestRunResult.ts
+++ b/src/result/sfProvarAutomationTestRunResult.ts
@@ -22,6 +22,12 @@ export class SfProvarAutomationTestRun extends SFProvarResult {
     let result: SfProvarCommandResult = { success: true };
 
     const errorObjects: Error[] | object[] = errorHandler.getErrors();
+    if (flags['output-file']) {
+      log(`The test results are stored in ${flags['output-file']}`);
+    } else {
+      log('-------------------------------------------------------------------------------------');
+    }
+
     if (errorObjects.length > 0) {
       if (!flags['json']) {
         throw messages.createError('error.MultipleFailure', errorHandler.errorsToStringArray());
@@ -31,12 +37,7 @@ export class SfProvarAutomationTestRun extends SFProvarResult {
         errors: errorObjects,
       };
     } else {
-      if (flags['output-file']) {
-        log(`The test results are stored in ${flags['output-file']}`);
-      } else {
-        log();
-        messages.messages.has('success_message') ? log(messages.getMessage('success_message')) : '';
-      }
+      messages.messages.has('success_message') ? log(messages.getMessage('success_message')) : '';
     }
     return result;
   }

--- a/src/result/sfProvarAutomationTestRunResult.ts
+++ b/src/result/sfProvarAutomationTestRunResult.ts
@@ -31,9 +31,7 @@ export class SfProvarAutomationTestRun extends SFProvarResult {
         errors: errorObjects,
       };
     } else {
-      if (flags['output-file']) {
-        log(`The test results are stored in ${flags['output-file']}`);
-      }
+      messages.messages.has('success_message') ? log(messages.getMessage('success_message')) : '';
     }
     return result;
   }

--- a/src/result/sfProvarAutomationTestRunResult.ts
+++ b/src/result/sfProvarAutomationTestRunResult.ts
@@ -31,6 +31,7 @@ export class SfProvarAutomationTestRun extends SFProvarResult {
         errors: errorObjects,
       };
     } else {
+      log();
       messages.messages.has('success_message') ? log(messages.getMessage('success_message')) : '';
     }
     return result;

--- a/src/result/sfProvarAutomationTestRunResult.ts
+++ b/src/result/sfProvarAutomationTestRunResult.ts
@@ -24,7 +24,6 @@ export class SfProvarAutomationTestRun extends SFProvarResult {
     const errorObjects: Error[] | object[] = errorHandler.getErrors();
     if (errorObjects.length > 0) {
       if (!flags['json']) {
-        log();
         throw messages.createError('error.MultipleFailure', errorHandler.errorsToStringArray());
       }
       result = {

--- a/src/result/sfProvarAutomationTestRunResult.ts
+++ b/src/result/sfProvarAutomationTestRunResult.ts
@@ -22,9 +22,9 @@ export class SfProvarAutomationTestRun extends SFProvarResult {
     let result: SfProvarCommandResult = { success: true };
 
     const errorObjects: Error[] | object[] = errorHandler.getErrors();
-    log();
     if (errorObjects.length > 0) {
       if (!flags['json']) {
+        log();
         throw messages.createError('error.MultipleFailure', errorHandler.errorsToStringArray());
       }
       result = {
@@ -32,7 +32,12 @@ export class SfProvarAutomationTestRun extends SFProvarResult {
         errors: errorObjects,
       };
     } else {
-      messages.messages.has('success_message') ? log(messages.getMessage('success_message')) : '';
+      if (flags['output-file']) {
+        log(`The test results are stored in ${flags['output-file']}`);
+      } else {
+        log();
+        messages.messages.has('success_message') ? log(messages.getMessage('success_message')) : '';
+      }
     }
     return result;
   }

--- a/test/assertion/runConstants.ts
+++ b/test/assertion/runConstants.ts
@@ -24,7 +24,14 @@ export const errorJson = {
 export const environmentName = 'Env';
 export const secretsPassword = "Priya@123+,-./:;_{|}~'()*<=>?[]^!#$%&";
 
-export const successfulResultSubstrings = ['Found test case.',
+export const successfulResultSubstrings = ['INFO:------------------',
+  'INFO:Validating License',
+  'Found Provar license.',
+  'Activating license ...',
+  'Provar license activated successfully.',
+  'INFO:-------------------------------------------------------------------------------------',
+  'INFO:ProvarDx execution started with Provar Version',
+  'Found test case.',
   'Test Output INFO: Adding Test File.  File/Folder:',
   'Test Output INFO: Added Execution Item.  tests',
   'Test Output INFO: Loading test case.  File:',
@@ -38,4 +45,4 @@ export const successfulResultSubstrings = ['Found test case.',
   'successfully.'
 ];
 
-export const outputFileAtRelativeLocation = './test/commands/provar/manager/testcase/Result.txt';
+export const outputFileAtRelativeLocation = './test/commands/provar/automation/test/Result.txt';

--- a/test/assertion/runConstants.ts
+++ b/test/assertion/runConstants.ts
@@ -23,3 +23,19 @@ export const errorJson = {
 };
 export const environmentName = 'Env';
 export const secretsPassword = "Priya@123+,-./:;_{|}~'()*<=>?[]^!#$%&";
+
+export const successfulResultSubstrings = ['Found test case.',
+  'Test Output INFO: Adding Test File.  File/Folder:',
+  'Test Output INFO: Added Execution Item.  tests',
+  'Test Output INFO: Loading test case.  File:',
+  'Test Output INFO: Added Execution Item.',
+  'Listening for transport dt_socket at address:',
+  'Test Run Started',
+  'Execution Item Started.  Title:',
+  'Execution Item Ended.  Title:',
+  'Test Run Ended',
+  'JUnit XML report written ',
+  'successfully.'
+];
+
+export const outputFileAtRelativeLocation = './test/commands/provar/manager/testcase/Result.txt';

--- a/test/commands/provar/automation/test/run.nut.ts
+++ b/test/commands/provar/automation/test/run.nut.ts
@@ -78,8 +78,7 @@ describe('provar automation test run NUTs', () => {
     ).shellOutput;
 
     expect(result.stdout).to.deep.contains(runConstants.successMessage);
-    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
-
+    runConstants.successfulResultSubstrings.forEach((resultSubstring) => {
       expect(result.stdout + result.stderr).to.include(resultSubstring);
     });
   });
@@ -89,8 +88,8 @@ describe('provar automation test run NUTs', () => {
     const configFilePatheData = fileSystem.readFileSync(configFilePath, { encoding: 'utf8' });
     const configFilePathParsed = JSON.parse(configFilePatheData);
     configFilePathParsed['PROVARDX_PROPERTIES_FILE_PATH'] = path.join(process.cwd(), './provardx-properties.json');
-    const updatedCongiFileData = JSON.stringify(configFilePathParsed, null, 4);
-    fileSystem.writeFileSync(configFilePath, updatedCongiFileData, 'utf8');
+    const updatedCongigFileData = JSON.stringify(configFilePathParsed, null, 4);
+    fileSystem.writeFileSync(configFilePath, updatedCongigFileData, 'utf8');
     const SET_PROVAR_HOME_VALUE = path.join(process.cwd(), './ProvarHome').replace(/\\/g, '/');
     const SET_PROJECT_PATH_VALUE = path.join(process.cwd(), './ProvarRegression/AutomationRevamp').replace(/\\/g, '/');
     const SET_RESULT_PATH = './';
@@ -119,7 +118,7 @@ describe('provar automation test run NUTs', () => {
       filePath = outputFile;
     }
     const fileContent = fileSystem.readFileSync(filePath, 'utf-8');
-    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+    runConstants.successfulResultSubstrings.forEach((resultSubstring) => {
       expect(fileContent).to.include(resultSubstring);
     });
   });
@@ -152,7 +151,7 @@ describe('provar automation test run NUTs', () => {
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND}`
     ).shellOutput;
     expect(result.stderr).to.deep.contains(runConstants.errorMessage);
-    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+    runConstants.successfulResultSubstrings.forEach((resultSubstring) => {
       expect(result.stdout + result.stderr).to.include(resultSubstring);
     });
   });
@@ -192,7 +191,7 @@ describe('provar automation test run NUTs', () => {
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND}`
     ).shellOutput;
     expect(result.stderr).to.deep.contains(runConstants.errorMessage);
-    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+    runConstants.successfulResultSubstrings.forEach((resultSubstring) => {
       expect(result.stdout + result.stderr).to.include(resultSubstring);
     });
   });

--- a/test/commands/provar/automation/test/run.nut.ts
+++ b/test/commands/provar/automation/test/run.nut.ts
@@ -88,8 +88,8 @@ describe('provar automation test run NUTs', () => {
     const configFilePatheData = fileSystem.readFileSync(configFilePath, { encoding: 'utf8' });
     const configFilePathParsed = JSON.parse(configFilePatheData);
     configFilePathParsed['PROVARDX_PROPERTIES_FILE_PATH'] = path.join(process.cwd(), './provardx-properties.json');
-    const updatedCongigFileData = JSON.stringify(configFilePathParsed, null, 4);
-    fileSystem.writeFileSync(configFilePath, updatedCongigFileData, 'utf8');
+    const updatedConfigFileData = JSON.stringify(configFilePathParsed, null, 4);
+    fileSystem.writeFileSync(configFilePath, updatedConfigFileData, 'utf8');
     const SET_PROVAR_HOME_VALUE = path.join(process.cwd(), './ProvarHome').replace(/\\/g, '/');
     const SET_PROJECT_PATH_VALUE = path.join(process.cwd(), './ProvarRegression/AutomationRevamp').replace(/\\/g, '/');
     const SET_RESULT_PATH = './';

--- a/test/commands/provar/automation/test/run.nut.ts
+++ b/test/commands/provar/automation/test/run.nut.ts
@@ -76,13 +76,16 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND}`
     ).shellOutput;
-    // expect(result.stdout).to.deep.equal(runConstants.successMessage);
+
+    expect(result.stdout).to.deep.contains(runConstants.successMessage);
     runConstants.successfulResultSubstrings.forEach(resultSubstring => {
-      expect(result.stdout).to.include(resultSubstring);
+
+      expect(result.stdout + result.stderr).to.include(resultSubstring);
     });
   });
 
   it('Test Run command should be successful in outputfile', async () => {
+    /* eslint-disable */
     const configFilePatheData = fileSystem.readFileSync(configFilePath, { encoding: 'utf8' });
     const configFilePathParsed = JSON.parse(configFilePatheData);
     configFilePathParsed['PROVARDX_PROPERTIES_FILE_PATH'] = path.join(process.cwd(), './provardx-properties.json');
@@ -107,7 +110,7 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND} -o ${outputFile}`
     ).shellOutput;
-    expect(result.stdout).to.deep.equal('The results were stored in ' + outputFile + '\n');
+    expect(result.stdout).to.deep.contains('The test results are stored in ' + outputFile + '\n');
     if (!outputFile.match('/')) {
       filePath = path.join(process.cwd(), 'result.txt');
     } else if (outputFile.startsWith('.')) {
@@ -124,11 +127,17 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND} --json`
     ).jsonOutput;
-    // expect(result).to.deep.equal(runConstants.SuccessJson);
-    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
-      expect(result).to.include(resultSubstring);
-    });
+    expect(result).to.deep.equal(runConstants.SuccessJson);
   });
+
+  it('Test Run command should be successful in case of outfile and return result in json', () => {
+    const outputFile = runConstants.outputFileAtRelativeLocation;
+    const result = execCmd<SfProvarCommandResult>(
+      `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND} -o ${outputFile} --json`
+    ).jsonOutput;
+    expect(result).to.deep.equal(runConstants.SuccessJson);
+  });
+
   it('Test Run command should not be successful and return the error', () => {
     interface PropertyFileJsonData {
       [key: string]: string | boolean | number | string[];
@@ -142,9 +151,9 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND}`
     ).shellOutput;
-    // expect(result.stderr).to.deep.equal(runConstants.errorMessage);
+    expect(result.stderr).to.deep.contains(runConstants.errorMessage);
     runConstants.successfulResultSubstrings.forEach(resultSubstring => {
-      expect(result.stdout).to.include(resultSubstring);
+      expect(result.stdout + result.stderr).to.include(resultSubstring);
     });
   });
 
@@ -152,10 +161,7 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND} --json`
     ).jsonOutput;
-    // expect(result).to.deep.equal(runConstants.errorJson);
-    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
-      expect(result).to.include(resultSubstring);
-    });
+    expect(result).to.deep.equal(runConstants.errorJson);
   });
 
   it('Test case should be Executed successfully when Environment is encrypted', () => {
@@ -185,9 +191,9 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND}`
     ).shellOutput;
-    // expect(result.stderr).to.deep.equal(runConstants.errorMessage);
+    expect(result.stderr).to.deep.contains(runConstants.errorMessage);
     runConstants.successfulResultSubstrings.forEach(resultSubstring => {
-      expect(result.stdout).to.include(resultSubstring);
+      expect(result.stdout + result.stderr).to.include(resultSubstring);
     });
   });
 
@@ -195,9 +201,6 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND} --json`
     ).jsonOutput;
-    // expect(result).to.deep.equal(runConstants.errorJson);
-    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
-      expect(result).to.include(resultSubstring);
-    });
+    expect(result).to.deep.equal(runConstants.errorJson);
   });
 });

--- a/test/commands/provar/automation/test/run.nut.ts
+++ b/test/commands/provar/automation/test/run.nut.ts
@@ -76,13 +76,58 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND}`
     ).shellOutput;
-    expect(result.stdout).to.deep.equal(runConstants.successMessage);
+    // expect(result.stdout).to.deep.equal(runConstants.successMessage);
+    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+      expect(result.stdout).to.include(resultSubstring);
+    });
+  });
+
+  it('Test Run command should be successful in outputfile', async () => {
+    const configFilePatheData = fileSystem.readFileSync(configFilePath, { encoding: 'utf8' });
+    const configFilePathParsed = JSON.parse(configFilePatheData);
+    configFilePathParsed['PROVARDX_PROPERTIES_FILE_PATH'] = path.join(process.cwd(), './provardx-properties.json');
+    const updatedCongiFileData = JSON.stringify(configFilePathParsed, null, 4);
+    fileSystem.writeFileSync(configFilePath, updatedCongiFileData, 'utf8');
+    const SET_PROVAR_HOME_VALUE = path.join(process.cwd(), './ProvarHome').replace(/\\/g, '/');
+    const SET_PROJECT_PATH_VALUE = path.join(process.cwd(), './ProvarRegression/AutomationRevamp').replace(/\\/g, '/');
+    const SET_RESULT_PATH = './';
+    interface PropertyFileJsonData {
+      [key: string]: string | boolean | number | string[];
+    }
+    const jsonDataString = fileSystem.readFileSync(jsonFilePath, 'utf-8');
+    const jsonData: PropertyFileJsonData = JSON.parse(jsonDataString) as PropertyFileJsonData;
+    jsonData.provarHome = SET_PROVAR_HOME_VALUE;
+    jsonData.projectPath = SET_PROJECT_PATH_VALUE;
+    jsonData.resultsPath = SET_RESULT_PATH;
+    jsonData.testCase = ['/Test Case 5.testcase'];
+    const updatedJsonDataString = JSON.stringify(jsonData, null, 2);
+    fileSystem.writeFileSync(jsonFilePath, updatedJsonDataString, 'utf-8');
+    const outputFile = runConstants.outputFileAtRelativeLocation;
+    let filePath = '';
+    const result = execCmd<SfProvarCommandResult>(
+      `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND} -o ${outputFile}`
+    ).shellOutput;
+    expect(result.stdout).to.deep.equal('The results were stored in ' + outputFile + '\n');
+    if (!outputFile.match('/')) {
+      filePath = path.join(process.cwd(), 'result.txt');
+    } else if (outputFile.startsWith('.')) {
+      filePath = path.join(process.cwd(), outputFile.replace(outputFile.charAt(0), ''));
+    } else {
+      filePath = outputFile;
+    }
+    const fileContent = fileSystem.readFileSync(filePath, 'utf-8');
+    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+      expect(fileContent).to.include(resultSubstring);
+    });
   });
   it('Test Run command should be successful and return result in json', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND} --json`
     ).jsonOutput;
-    expect(result).to.deep.equal(runConstants.SuccessJson);
+    // expect(result).to.deep.equal(runConstants.SuccessJson);
+    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+      expect(result).to.include(resultSubstring);
+    });
   });
   it('Test Run command should not be successful and return the error', () => {
     interface PropertyFileJsonData {
@@ -97,14 +142,20 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND}`
     ).shellOutput;
-    expect(result.stderr).to.deep.equal(runConstants.errorMessage);
+    // expect(result.stderr).to.deep.equal(runConstants.errorMessage);
+    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+      expect(result.stdout).to.include(resultSubstring);
+    });
   });
 
   it('Test Run command should not be successful and return result in json format', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND} --json`
     ).jsonOutput;
-    expect(result).to.deep.equal(runConstants.errorJson);
+    // expect(result).to.deep.equal(runConstants.errorJson);
+    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+      expect(result).to.include(resultSubstring);
+    });
   });
 
   it('Test case should be Executed successfully when Environment is encrypted', () => {
@@ -134,13 +185,19 @@ describe('provar automation test run NUTs', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND}`
     ).shellOutput;
-    expect(result.stderr).to.deep.equal(runConstants.errorMessage);
+    // expect(result.stderr).to.deep.equal(runConstants.errorMessage);
+    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+      expect(result.stdout).to.include(resultSubstring);
+    });
   });
 
   it('Test case should be Executed successfully when Environment is encrypted and return result in json format', () => {
     const result = execCmd<SfProvarCommandResult>(
       `${commandConstants.SF_PROVAR_AUTOMATION_TEST_RUN_COMMAND} --json`
     ).jsonOutput;
-    expect(result).to.deep.equal(runConstants.errorJson);
+    // expect(result).to.deep.equal(runConstants.errorJson);
+    runConstants.successfulResultSubstrings.forEach(resultSubstring => {
+      expect(result).to.include(resultSubstring);
+    });
   });
 });


### PR DESCRIPTION
sf provar automation test run
outputs the test run logs on the terminal by default
outputs the test run logs to a file when the -o | --output-file param is used, with the file name as specified
Changes:- have added a check for output file flag before writing to the file.
Have used the same mechanism as earlier that is piping the child process output , instead of directly using execSync for logging the output to console, as in case of logging to the console we  also need consolidated results which is only possible if we are storing the logs anywhere in the code.