### PR TITLE
PDX-221: Metadata not getting for overriden username in DX 

### DIFF
--- a/src/commands/provar/automation/metadata/download.ts
+++ b/src/commands/provar/automation/metadata/download.ts
@@ -50,8 +50,6 @@ export default class ProvarMetadataDownload extends SfCommand<SfProvarCommandRes
 
       if (flags.connections) {
         this.doConnectionOverrides(propertiesInstance, flags?.connections);
-
-        // propertiesInstance.connectionName = removeSpaces(flags.connections);
       }
 
       const rawProperties = JSON.stringify(propertiesInstance);

--- a/src/commands/provar/automation/metadata/download.ts
+++ b/src/commands/provar/automation/metadata/download.ts
@@ -97,26 +97,21 @@ export default class ProvarMetadataDownload extends SfCommand<SfProvarCommandRes
 
     if (properties.connectionOverride && flagConnections) {
       const connections = removeSpaces(flagConnections).split(',');
-      const connectionOverrideProperty = [];
+      const connectionOverride: { connection: string; username: string }[] = [];
+
       for (const override of properties.connectionOverride) {
         if (connections.indexOf(override.connection) !== -1) {
-          connectionOverrideProperty.push(override);
+          connectionOverride.push(override);
         }
       }
 
-      const connectionProperty: string[] = [];
-      const overridenConnections: string[] = [];
-      for (const override of connectionOverrideProperty) {
-        overridenConnections.push(override?.connection);
-      }
-      for (const connection of connections) {
-        if (overridenConnections.indexOf(connection) == -1) {
-          connectionProperty.push(connection);
-        }
-      }
+      const connectionProperty: string[] = connections.filter(
+        (connection) => !connectionOverride.some((override) => override?.connection === connection)
+      );
+
       properties.connectionName = connectionProperty.join(',');
 
-      properties.connectionOverride = connectionOverrideProperty;
+      properties.connectionOverride = connectionOverride;
     }
   }
 }

--- a/src/commands/provar/automation/metadata/download.ts
+++ b/src/commands/provar/automation/metadata/download.ts
@@ -91,27 +91,22 @@ export default class ProvarMetadataDownload extends SfCommand<SfProvarCommandRes
   }
 
   private doConnectionOverrides(properties: any, flagConnections: string): void {
-    if (!properties.connectionOverride && !flagConnections) {
-      return;
-    }
+    const connections = removeSpaces(flagConnections).split(',');
+    const connectionOverride: { connection: string; username: string }[] = [];
 
-    if (properties.connectionOverride && flagConnections) {
-      const connections = removeSpaces(flagConnections).split(',');
-      const connectionOverride: { connection: string; username: string }[] = [];
-
+    if (properties.connectionOverride) {
       for (const override of properties.connectionOverride) {
         if (connections.indexOf(override.connection) !== -1) {
           connectionOverride.push(override);
         }
       }
-
-      const connectionProperty: string[] = connections.filter(
-        (connection) => !connectionOverride.some((override) => override?.connection === connection)
-      );
-
-      properties.connectionName = connectionProperty.join(',');
-
       properties.connectionOverride = connectionOverride;
     }
+
+    const connectionProperty: string[] = connections.filter(
+      (connection) => !connectionOverride.some((override) => override?.connection === connection)
+    );
+
+    properties.connectionName = connectionProperty.join(',');
   }
 }


### PR DESCRIPTION
This PR is for Fix2
Issue1: If both connectionName and connectionOverrides existed in the properties.json then it was not considering connectionOverrides
RCA: Return statement was there only after iterating connectionNames hence making connectionOverrides code unreacheable on Provar Installer side.
Fix1: removed that return statement

Issue 2: After fixing issue1 there comes an issue when the same connection is there in connectionName and in connectionOverrides then also metadata is downloaded for the connectionName but not with the overridden username in connectionOverride.
RCA: After properly populating connectionOverrides for the flagConnections we were also passing flagConnections under the connectionName property, hence making 2 dxConnections over the studio side, 1 for connectionName and the other for connectionOverride but with the same connection name attribute. Further, we are creating apexConnection for downloading the metadata which is cached on the basis of connection name only and when it goes to create apexConnection for connectionOverride as it has the same name as the connectionName earlier it returns the previously created apexConnection only with the connectionName username.
Fix2: only passed flagConnection not there in connectionOverride to connectionName property of properties.json file